### PR TITLE
Fix element scrolling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,8 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 
 Fixed
 """""
-- Bug in logger for bool_url_does_not_contain function 
+- Bug in logger for bool_url_does_not_contain function
+- Bug in scrolling functionality within an element
 
 `v1.0.0 <https://github.com/cmagovuk/selene-core/releases/tag/v1.0.0>`_ - 2022-06-08
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/selene/core/selenium/element.py
+++ b/selene/core/selenium/element.py
@@ -168,9 +168,7 @@ class ElementSelene(Element):
         position_new = position + int(0.5 * height_window)
         position_new = min(position_new, height)
         script_scroll_to(driver, position_new, self)
-        return bool_scroll_position_changed(
-            driver, self, wait, self.logger, position
-        )
+        return bool_scroll_position_changed(driver, self, wait, self.logger, position)
 
     def scroll_to(self, driver, position_new, wait=WAIT_NORMAL):
         """
@@ -190,9 +188,7 @@ class ElementSelene(Element):
         """
         position = script_get_scroll_position(driver, self)
         script_scroll_to(driver, position_new, self)
-        return bool_scroll_position_changed(
-            driver, self, wait, self.logger, position
-        )
+        return bool_scroll_position_changed(driver, self, wait, self.logger, position)
 
     def scroll_to_bottom(self, driver, wait=WAIT_NORMAL):
         """
@@ -212,6 +208,4 @@ class ElementSelene(Element):
         """
         height = script_get_scroll_height(driver, self)
         script_scroll_to(driver, height, self)
-        return bool_scroll_height_changed(
-            driver, wait, self.logger, height, element=self
-        )
+        return bool_scroll_height_changed(driver, wait, self.logger, height, element=self)

--- a/selene/core/selenium/element.py
+++ b/selene/core/selenium/element.py
@@ -51,7 +51,7 @@ class ElementSelene(Element):
         ----------
             out : ElementSelene object wrapping the parent element
         """
-        return ElementSelene(script_get_parent(driver, self.element))
+        return ElementSelene(script_get_parent(driver, self))
 
     def find(self, by, identifier, wait=WAIT_NORMAL, log=True):
         """
@@ -144,7 +144,7 @@ class ElementSelene(Element):
             output : bool
                 True if the operation was successful, False otherwise
         """
-        return script_click_element(driver, self.element)
+        return script_click_element(driver, self)
 
     def scroll_down(self, driver, wait=WAIT_NORMAL):
         """
@@ -163,13 +163,13 @@ class ElementSelene(Element):
                 True if the operation was successful, False otherwise
         """
         height_window = driver.get_window_size()["height"]
-        height = script_get_scroll_height(driver, self.element)
-        position = script_get_scroll_position(driver, self.element)
+        height = script_get_scroll_height(driver, self)
+        position = script_get_scroll_position(driver, self)
         position_new = position + int(0.5 * height_window)
         position_new = min(position_new, height)
-        script_scroll_to(driver, position_new, self.element)
+        script_scroll_to(driver, position_new, self)
         return bool_scroll_position_changed(
-            driver, self.element, wait, self.logger, position
+            driver, self, wait, self.logger, position
         )
 
     def scroll_to(self, driver, position_new, wait=WAIT_NORMAL):
@@ -188,10 +188,10 @@ class ElementSelene(Element):
             output : bool
                 True if the operation was successful, False otherwise
         """
-        position = script_get_scroll_position(driver, self.element)
-        script_scroll_to(driver, position_new, self.element)
+        position = script_get_scroll_position(driver, self)
+        script_scroll_to(driver, position_new, self)
         return bool_scroll_position_changed(
-            driver, self.element, wait, self.logger, position
+            driver, self, wait, self.logger, position
         )
 
     def scroll_to_bottom(self, driver, wait=WAIT_NORMAL):
@@ -210,8 +210,8 @@ class ElementSelene(Element):
             output : bool
                 True if the operation was successful, False otherwise
         """
-        height = script_get_scroll_height(driver, self.element)
-        script_scroll_to(driver, height, self.element)
+        height = script_get_scroll_height(driver, self)
+        script_scroll_to(driver, height, self)
         return bool_scroll_height_changed(
-            driver, wait, self.logger, height, element=self.element
+            driver, wait, self.logger, height, element=self
         )

--- a/selene/core/selenium/scripts.py
+++ b/selene/core/selenium/scripts.py
@@ -21,7 +21,7 @@ def script_get_scroll_height(driver, element=None):
         script = "return document.body.scrollHeight;"
         return driver.execute_script(script)
     script = "return arguments[0].scrollHeight;"
-    return driver.execute_script(script, element)
+    return driver.execute_script(script, element.element)
 
 
 def script_get_scroll_position(driver, element=None):
@@ -74,8 +74,8 @@ def script_scroll_to(driver, position, element=None):
     if element is None:
         script = "window.scrollTo(0, arguments[0]); return true;"
         return driver.execute_script(script, position)
-    script = "'arguments[0].scrollTop=arguments[1]'; return true;"
-    return driver.execute_script(script, element, position)
+    script = "arguments[0].scrollTop=arguments[1]; return true;"
+    return driver.execute_script(script, element.element, position)
 
 
 def script_click_element(driver, element):
@@ -96,7 +96,7 @@ def script_click_element(driver, element):
             True if the operation was successful, False otherwise
     """
     script = "arguments[0].click(); return true;"
-    return driver.execute_script(script, element)
+    return driver.execute_script(script, element.element)
 
 
 def script_get_parent(driver, element):
@@ -117,7 +117,7 @@ def script_get_parent(driver, element):
             the parent WebElement
     """
     script = "return arguments[0].parentElement;"
-    return driver.execute_script(script, element)
+    return driver.execute_script(script, element.element)
 
 
 def script_expand_all_by_class_name(

--- a/selene/core/selenium/scripts.py
+++ b/selene/core/selenium/scripts.py
@@ -74,7 +74,7 @@ def script_scroll_to(driver, position, element=None):
     if element is None:
         script = "window.scrollTo(0, arguments[0]); return true;"
         return driver.execute_script(script, position)
-    script = "arguments[0].scrollTo(0, arguments[1]); return true;"
+    script = "'arguments[0].scrollTop=arguments[1]'; return true;"
     return driver.execute_script(script, element, position)
 
 

--- a/tests/test_selene_core_selenium.py
+++ b/tests/test_selene_core_selenium.py
@@ -53,8 +53,8 @@ def test_bool_yoffset_changed():
     assert bool_yoffset_changed(driver, wait = 1, yoffset = orig_offset, logger = None) == True
     
 def test_bool_scroll_position_changed():
-    page = PageSelene.from_url(driver=driver, url = "http://www.scrapethissite.com/pages/frames/")
-    el = page.find(driver, by = By.ID, identifier = 'iframe')
+    page = PageSelene.from_url(driver=driver, url = "https://www.gov.uk/cma-cases")
+    el = page.find(driver, by = By.XPATH, identifier = '//*[@id="case_type"]')
     orig_pos = script_get_scroll_position(driver, el)
     el.scroll_to_bottom(driver)
     assert bool_scroll_position_changed(driver, element = el, wait = 1, position = orig_pos, logger = None) == True

--- a/tests/test_selene_core_selenium.py
+++ b/tests/test_selene_core_selenium.py
@@ -52,12 +52,12 @@ def test_bool_yoffset_changed():
     page.scroll_down(driver, wait = 1)
     assert bool_yoffset_changed(driver, wait = 1, yoffset = orig_offset, logger = None) == True
     
-# def test_bool_scroll_position_changed():
-#     page = PageSelene.from_url(driver=driver, url = "http://www.scrapethissite.com/pages/frames/")
-#     el = page.find(driver, by = By.ID, identifier = 'iframe')
-#     orig_pos = script_get_scroll_position(driver, el)
-#     el.scroll_to_bottom(driver)
-#     assert bool_scroll_position_changed(driver, element = el, wait = 1, position = orig_pos, logger = None) == True
+def test_bool_scroll_position_changed():
+    page = PageSelene.from_url(driver=driver, url = "http://www.scrapethissite.com/pages/frames/")
+    el = page.find(driver, by = By.ID, identifier = 'iframe')
+    orig_pos = script_get_scroll_position(driver, el)
+    el.scroll_to_bottom(driver)
+    assert bool_scroll_position_changed(driver, element = el, wait = 1, position = orig_pos, logger = None) == True
     
 def test_bool_scroll_height_changed():
     page = PageSelene.from_url(driver=driver, url = "http://www.scrapethissite.com/pages/forms/")


### PR DESCRIPTION
* there was some inconsistency in how we were calling ElementSelene.element - this was causing the original error reported in the bug
* changed the way we scroll within an element - basically a different bit of javascript - this was a further issue, unclear if the previous function ever worked correctly
* tested on a new example from gov.uk - something strange going on with the original example from scrapethissite